### PR TITLE
fixed booking start date before today bug

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -3,13 +3,23 @@ class Booking < ApplicationRecord
     belongs_to :room
     validates :start_date, :end_date, presence: true
     validate :end_date_after_start_date
+    validate :start_date_after_today
 
     private
 
-    def end_date_after_start_date
-      return if end_date.blank? || start_date.blank?
-      if end_date < start_date
-        errors.add(:end_date, "must be after the start date")
-      end
+  def start_date_after_today
+    return if end_date.blank? || start_date.blank?
+
+    if start_date < Date.today
+      errors.add(:start_date, "must be after today")
+    end
   end
+
+  def end_date_after_start_date
+    return if end_date.blank? || start_date.blank?
+
+    if end_date < start_date
+      errors.add(:end_date, "must be after the start date")
+    end
+ end
 end


### PR DESCRIPTION
Added an Action to Booking Model to block reservations with start_date before today. Please check code before merging. I completed pull request before creating update, but recall we have several updates pending from yesterday afternoon.